### PR TITLE
Chapter 2 - Validating Requests

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,99 +1,13 @@
 const fastify = require("fastify")({ logger: true });
-const { nanoid } = require("nanoid");
+const openapiGlue = require("fastify-openapi-glue");
+const Service = require("./service.js");
 
-/* Example of defining a route for GET / */
+const glueOptions = {
+  specification: `${__dirname}/schema.yaml`,
+  service: new Service(),
+};
 
-// fastify.get("/", (req, res) => {
-//   res.send({ message: "hello world!" });
-// });
-
-// Our temporary database, an array of restaurants :)
-let restaurants = [
-  {
-    id: "abc",
-    name: "Puerto Viejo",
-    cuisine: "dominican",
-    hasTakeout: true,
-  },
-  {
-    id: "def",
-    name: "Cataldo",
-    cuisine: "italian",
-    hasTakeout: false,
-  },
-];
-
-// GET /restaurants
-fastify.get("/restaurants", async (req, res) => {
-  res.send(restaurants);
-});
-
-// POST /restaurants
-fastify.post("/restaurants", async (req, res) => {
-  // get newRestaurant properties from request body
-  const newRestaurant = req.body;
-
-  // generate a random UUID and add it to newRestaurant
-  newRestaurant.id = nanoid();
-
-  // save new restaurant to db
-  restaurants.push(newRestaurant);
-
-  res.code(201).send(newRestaurant);
-});
-
-// GET /restaurants/:id
-fastify.get("/restaurants/:id", async (req, res) => {
-  // get id from path parameters
-  const { id } = req.params;
-
-  // Get restaurant from database
-  const restaurant = restaurants.find((r) => r.id === id);
-
-  // Send restaurant in response if found, otherwise send 404
-  if (restaurant) {
-    res.send(restaurant);
-  } else {
-    res.code(404).send({ message: `Restaurant with id '${id}' not found` });
-  }
-});
-
-// PUT /restaurants/:id
-fastify.put("/restaurants/:id", async (req, res) => {
-  // get id from path parameters
-  const { id } = req.params;
-
-  // check that restaurant exists. If not found, `foundIndex` will equal -1
-  const foundIndex = restaurants.findIndex((r) => r.id === id);
-
-  if (foundIndex > -1) {
-    // Update restaurant in database at foundIndex
-    const prevData = restaurants[foundIndex];
-    restaurants[foundIndex] = { ...prevData, ...req.body };
-    // send empty response OK
-    res.code(204).send();
-  } else {
-    res.code(404).send({ message: `Restaurant with id '${id}' not found` });
-  }
-});
-
-// DELETE /restaurants/:id
-fastify.delete("/restaurants/:id", async (req, res) => {
-  // get id from path parameters
-  const { id } = req.params;
-
-  // check that restaurant exists. If not found, `foundIndex` will equal -1
-  const foundIndex = restaurants.findIndex((r) => r.id === id);
-
-  if (foundIndex > -1) {
-    // Delete restaurant from database
-    restaurants = restaurants.splice(foundIndex, 1);
-    // send empty response OK
-    res.code(204).send();
-  } else {
-    res.code(404).send({ message: `Restaurant with id '${id}' not found` });
-  }
-});
+fastify.register(openapiGlue, glueOptions);
 
 // Start the server!
 const start = async () => {

--- a/src/service.js
+++ b/src/service.js
@@ -1,0 +1,87 @@
+const { nanoid } = require("nanoid");
+
+let restaurants = [
+  {
+    id: "4Oj9hUC-EwrYdn9uOYeui",
+    name: "Puerto Viejo",
+    cuisine: "dominican",
+    hasTakeout: true,
+  },
+  {
+    id: "8NBUuV1hY1mUEomWxnws1",
+    name: "Sadas",
+    cuisine: "japanese",
+    hasTakeout: true,
+  },
+];
+
+class Service {
+  constructor() {}
+
+  getRestaurants(_req, res) {
+    res.send(restaurants);
+  }
+
+  addRestaurant(req, res) {
+    // get newRestaurant properties from request body
+    const newRestaurant = req.body;
+    // generate a unique random id and add it to newRestaurant
+    newRestaurant.id = nanoid();
+
+    // save new restaurant to db
+    restaurants.push(newRestaurant);
+
+    res.code(201).send(newRestaurant);
+  }
+
+  getRestaurant(req, res) {
+    // get id from path parameters
+    const { id } = req.params;
+    // Get restaurant from database
+    const restaurant = restaurants.find((r) => r.id === id);
+
+    // Send restaurant in response if found, otherwise send 404
+    if (restaurant) {
+      res.send(restaurant);
+    } else {
+      res.code(404).send({ message: `Restaurant with id '${id}' not found` });
+    }
+  }
+
+  updateRestaurant(req, res) {
+    // get id from path parameters
+    const { id } = req.params;
+
+    // check that restuarant exists. If not found, `foundIndex` will equal -1
+    const foundIndex = restaurants.findIndex((r) => r.id === id);
+
+    if (foundIndex > -1) {
+      // Update restaurant in database
+      const prevData = restaurants[foundIndex];
+      restaurants[foundIndex] = { ...prevData, ...req.body };
+      // send empty response with status 204
+      res.code(204).send();
+    } else {
+      res.code(404).send({ message: `Restaurant with id '${id}' not found` });
+    }
+  }
+
+  deleteRestaurant(req, res) {
+    // get id from path parameters
+    const { id } = req.params;
+
+    // check that restuarant exists. If not found, `foundIndex` will equal -1
+    const foundIndex = restaurants.findIndex((r) => r.id === id);
+
+    if (foundIndex > -1) {
+      // Delete restaurant from database
+      restaurants = restaurants.splice(foundIndex, 1);
+      // send empty response with status 204
+      res.code(204).send();
+    } else {
+      res.code(404).send({ message: `Restaurant with id '${id}' not found` });
+    }
+  }
+}
+
+module.exports = Service;


### PR DESCRIPTION
We need to make sure our API returns a `400 Bad Request` error if a client makes a crazy request that doesn't match our schema, like:
```
POST /restaurants
with a Body of { "someCrazyProperty": "nonsense"}
```

We can enforce our OpenAPI schema on our fastify API using the plugin library [`fastify-openapi-glue`](https://www.npmjs.com/package/fastify-openapi-glue)

This library identifies each of our paths by their `operationId` in our `schema.yaml`, and converts them into fastify routes with the correct request methods. Better yet, the generated routes check each request to that route and make sure it fits our schema, or else it sends an error to the client! 

API First makes life easy :) 
