### PR TITLE
Chapter 2 - Validating Requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "fastify": "^3.27.0",
+        "fastify-openapi-glue": "^2.6.5",
         "nanoid": "^3.2.0"
       },
       "devDependencies": {
@@ -23,6 +24,53 @@
       "dependencies": {
         "ajv": "^6.12.6"
       }
+    },
+    "node_modules/@seriousme/openapi-schema-validator": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-1.6.0.tgz",
+      "integrity": "sha512-HTcRsLMZxCkgSCgHTlKnOpte4cTI/j64aHU7HyRaLNtXrCMikyL0K26cj4vO8Qxx6in+YufrjyDBbB59gT1x3w==",
+      "dependencies": {
+        "ajv": "^8.6.3",
+        "ajv-draft-04": "^1.0.0",
+        "ajv-formats": "^2.1.1",
+        "js-yaml": "^4.1.0"
+      },
+      "bin": {
+        "validate-api": "bin/validate-api-cli.js"
+      }
+    },
+    "node_modules/@seriousme/openapi-schema-validator/node_modules/ajv": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+      "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@seriousme/openapi-schema-validator/node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@seriousme/openapi-schema-validator/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "0.14.0",
@@ -70,6 +118,42 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+      "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/ansi-align": {
       "version": "3.0.1",
@@ -121,6 +205,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
@@ -565,6 +654,47 @@
       "resolved": "https://registry.npmjs.org/fastify-error/-/fastify-error-0.3.1.tgz",
       "integrity": "sha512-oCfpcsDndgnDVgiI7bwFKAun2dO+4h84vBlkWsWnz/OUK9Reff5UFoFl241xTiLeHWX/vU9zkDVXqYUxjOwHcQ=="
     },
+    "node_modules/fastify-openapi-glue": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/fastify-openapi-glue/-/fastify-openapi-glue-2.6.5.tgz",
+      "integrity": "sha512-c2zcVQO/5mUYxKBZyq/RtvtAf/4v3ZCOAR6fYyn1j32uO9VittvZmhracpBcLzfOZ/48iAAwVLb7125ypOKXvg==",
+      "dependencies": {
+        "@seriousme/openapi-schema-validator": "^1.3.0",
+        "ajv": "^8.6.2",
+        "ajv-formats": "^2.1.1",
+        "fastify-plugin": "^3.0.0",
+        "js-yaml": "^4.1.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "openapi-glue": "bin/openapi-glue-cli.js"
+      }
+    },
+    "node_modules/fastify-openapi-glue/node_modules/ajv": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+      "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fastify-openapi-glue/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/fastify-plugin": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-3.0.1.tgz",
+      "integrity": "sha512-qKcDXmuZadJqdTm6vlCqioEbyewF60b/0LOFCcYN1B6BIZGlYJumWWOYs70SFYLDAH4YqdE1cxH/RKMG7rFxgA=="
+    },
     "node_modules/fastify-warning": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/fastify-warning/-/fastify-warning-0.2.0.tgz",
@@ -884,6 +1014,17 @@
       "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
       "dev": true
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
@@ -1015,8 +1156,7 @@
     "node_modules/minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -1696,6 +1836,41 @@
         "ajv": "^6.12.6"
       }
     },
+    "@seriousme/openapi-schema-validator": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-1.6.0.tgz",
+      "integrity": "sha512-HTcRsLMZxCkgSCgHTlKnOpte4cTI/j64aHU7HyRaLNtXrCMikyL0K26cj4vO8Qxx6in+YufrjyDBbB59gT1x3w==",
+      "requires": {
+        "ajv": "^8.6.3",
+        "ajv-draft-04": "^1.0.0",
+        "ajv-formats": "^2.1.1",
+        "js-yaml": "^4.1.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.9.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+          "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-draft-04": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+          "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+          "requires": {}
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -1731,6 +1906,32 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "requires": {
+        "ajv": "^8.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.9.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+          "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
       }
     },
     "ansi-align": {
@@ -1771,6 +1972,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
+    },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "atomic-sleep": {
       "version": "1.0.0",
@@ -2116,6 +2322,42 @@
       "resolved": "https://registry.npmjs.org/fastify-error/-/fastify-error-0.3.1.tgz",
       "integrity": "sha512-oCfpcsDndgnDVgiI7bwFKAun2dO+4h84vBlkWsWnz/OUK9Reff5UFoFl241xTiLeHWX/vU9zkDVXqYUxjOwHcQ=="
     },
+    "fastify-openapi-glue": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/fastify-openapi-glue/-/fastify-openapi-glue-2.6.5.tgz",
+      "integrity": "sha512-c2zcVQO/5mUYxKBZyq/RtvtAf/4v3ZCOAR6fYyn1j32uO9VittvZmhracpBcLzfOZ/48iAAwVLb7125ypOKXvg==",
+      "requires": {
+        "@seriousme/openapi-schema-validator": "^1.3.0",
+        "ajv": "^8.6.2",
+        "ajv-formats": "^2.1.1",
+        "fastify-plugin": "^3.0.0",
+        "js-yaml": "^4.1.0",
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.9.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+          "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
+    },
+    "fastify-plugin": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-3.0.1.tgz",
+      "integrity": "sha512-qKcDXmuZadJqdTm6vlCqioEbyewF60b/0LOFCcYN1B6BIZGlYJumWWOYs70SFYLDAH4YqdE1cxH/RKMG7rFxgA=="
+    },
     "fastify-warning": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/fastify-warning/-/fastify-warning-0.2.0.tgz",
@@ -2350,6 +2592,14 @@
       "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
       "dev": true
     },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
@@ -2457,8 +2707,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "fastify": "^3.27.0",
+    "fastify-openapi-glue": "^2.6.5",
     "nanoid": "^3.2.0"
   },
   "devDependencies": {

--- a/src/server.js
+++ b/src/server.js
@@ -1,99 +1,13 @@
 const fastify = require("fastify")({ logger: true });
-const { nanoid } = require("nanoid");
+const openapiGlue = require("fastify-openapi-glue");
+const Service = require("./service");
 
-/* Example of defining a route for GET / */
+const glueOptions = {
+  specification: `${__dirname}/schema.yaml`,
+  service: new Service(),
+};
 
-// fastify.get("/", async (req, res) => {
-//   res.send({ message: "hello world!" });
-// });
-
-// Our temporary database, an array of restaurants :)
-let restaurants = [
-  {
-    id: "abc",
-    name: "Puerto Viejo",
-    cuisine: "dominican",
-    hasTakeout: true,
-  },
-  {
-    id: "def",
-    name: "Cataldo",
-    cuisine: "italian",
-    hasTakeout: false,
-  },
-];
-
-// GET /restaurants
-fastify.get("/restaurants", async (req, res) => {
-  res.send(restaurants);
-});
-
-// POST /restaurants
-fastify.post("/restaurants", async (req, res) => {
-  // get newRestaurant properties from request body
-  const newRestaurant = req.body;
-
-  // generate a random UUID and add it to newRestaurant
-  newRestaurant.id = nanoid();
-
-  // save new restaurant to db
-  restaurants.push(newRestaurant);
-
-  res.code(201).send(newRestaurant);
-});
-
-// GET /restaurants/:id
-fastify.get("/restaurants/:id", async (req, res) => {
-  // get id from path parameters
-  const { id } = req.params;
-
-  // Get restaurant from database
-  const restaurant = restaurants.find((r) => r.id === id);
-
-  // Send restaurant in response if found, otherwise send 404
-  if (restaurant) {
-    res.send(restaurant);
-  } else {
-    res.code(404).send({ message: `Restaurant with id '${id}' not found` });
-  }
-});
-
-// PUT /restaurants/:id
-fastify.put("/restaurants/:id", async (req, res) => {
-  // get id from path parameters
-  const { id } = req.params;
-
-  // check that restaurant exists. If not found, `foundIndex` will equal -1
-  const foundIndex = restaurants.findIndex((r) => r.id === id);
-
-  if (foundIndex > -1) {
-    // Update restaurant in database at foundIndex
-    const prevData = restaurants[foundIndex];
-    restaurants[foundIndex] = { ...prevData, ...req.body };
-    // send empty response OK
-    res.code(204).send();
-  } else {
-    res.code(404).send({ message: `Restaurant with id '${id}' not found` });
-  }
-});
-
-// DELETE /restaurants/:id
-fastify.delete("/restaurants/:id", async (req, res) => {
-  // get id from path parameters
-  const { id } = req.params;
-
-  // check that restaurant exists. If not found, `foundIndex` will equal -1
-  const foundIndex = restaurants.findIndex((r) => r.id === id);
-
-  if (foundIndex > -1) {
-    // Delete restaurant from database
-    restaurants.splice(foundIndex, 1);
-    // send empty response OK
-    res.code(204).send();
-  } else {
-    res.code(404).send({ message: `Restaurant with id '${id}' not found` });
-  }
-});
+fastify.register(openapiGlue, glueOptions);
 
 // Start the server!
 const start = async () => {

--- a/src/service.js
+++ b/src/service.js
@@ -1,0 +1,87 @@
+const { nanoid } = require("nanoid");
+
+let restaurants = [
+  {
+    id: "4Oj9hUC-EwrYdn9uOYeui",
+    name: "Puerto Viejo",
+    cuisine: "dominican",
+    hasTakeout: true,
+  },
+  {
+    id: "8NBUuV1hY1mUEomWxnws1",
+    name: "Sadas",
+    cuisine: "japanese",
+    hasTakeout: true,
+  },
+];
+
+class Service {
+  constructor() {}
+
+  getRestaurants(_req, res) {
+    res.send(restaurants);
+  }
+
+  addRestaurant(req, res) {
+    // get newRestaurant properties from request body
+    const newRestaurant = req.body;
+    // generate a unique random id and add it to newRestaurant
+    newRestaurant.id = nanoid();
+
+    // save new restaurant to db
+    restaurants.push(newRestaurant);
+
+    res.code(201).send(newRestaurant);
+  }
+
+  getRestaurant(req, res) {
+    // get id from path parameters
+    const { id } = req.params;
+    // Get restaurant from database
+    const restaurant = restaurants.find((r) => r.id === id);
+
+    // Send restaurant in response if found, otherwise send 404
+    if (restaurant) {
+      res.send(restaurant);
+    } else {
+      res.code(404).send({ message: `Restaurant with id '${id}' not found` });
+    }
+  }
+
+  updateRestaurant(req, res) {
+    // get id from path parameters
+    const { id } = req.params;
+
+    // check that restuarant exists. If not found, `foundIndex` will equal -1
+    const foundIndex = restaurants.findIndex((r) => r.id === id);
+
+    if (foundIndex > -1) {
+      // Update restaurant in database
+      const prevData = restaurants[foundIndex];
+      restaurants[foundIndex] = { ...prevData, ...req.body };
+      // send empty response with status 204
+      res.code(204).send();
+    } else {
+      res.code(404).send({ message: `Restaurant with id '${id}' not found` });
+    }
+  }
+
+  deleteRestaurant(req, res) {
+    // get id from path parameters
+    const { id } = req.params;
+
+    // check that restuarant exists. If not found, `foundIndex` will equal -1
+    const foundIndex = restaurants.findIndex((r) => r.id === id);
+
+    if (foundIndex > -1) {
+      // Delete restaurant from database
+      restaurants.splice(foundIndex, 1);
+      // send empty response with status 204
+      res.code(204).send();
+    } else {
+      res.code(404).send({ message: `Restaurant with id '${id}' not found` });
+    }
+  }
+}
+
+module.exports = Service;


### PR DESCRIPTION
We need to make sure our API returns a `400 Bad Request` error if a client makes a crazy request that doesn't match our schema, like:
```
POST /restaurants
with a Body of { "someCrazyProperty": "nonsense"}
```

We can enforce our OpenAPI schema on our fastify API using the plugin library [`fastify-openapi-glue`](https://www.npmjs.com/package/fastify-openapi-glue)

This library identifies each of our paths by their `operationId` in our `schema.yaml`, and converts them into fastify routes with the correct request methods. Better yet, the generated routes check each request to that route and make sure it fits our schema, or else it sends an error to the client! 

API First makes life easy :) 
